### PR TITLE
32 upload avatar to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,20 +9,26 @@
 # 02-Aug-2021  Wayne Shih              Initial create from GitHub
 # 03-Aug-2021  Wayne Shih              Ignore vagrant-related files and PyCharm-related config
 # 07-Aug-2021  Wayne Shih              Ignore PyCharm-related config
+# 23-Mar-2022  Wayne Shih              Ignore vscode-related config and user-uploaded files
 # $HISTORY$
 # =================================================================================================
 
 
-# <Wayne Shih> 03-Aug-2021 
+# <Wayne Shih> 03-Aug-2021
 # vagrant-related files
 *.box
 .vagrant
 Vagrantfile
 
-# <Wayne Shih> 03-Aug-2021 
-# PyCharm-related config
+# <Wayne Shih> 22-Mar-2022
+# PyCharm and vscode related config
 .pycharm_helpers/
 .idea
+.vscode/
+
+# <Wayne Shih> 22-Mar-2022
+# The directory that will hold user-uploaded files
+media/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ File description:
 24-Aug-2021  Wayne Shih              Initial create and add badges
 17-Oct-2021  Wayne Shih              Add codacy badges
 06-Nov-2021  Wayne Shih              Add pylint badge
-19-Mar-2022  Wayne Shih              Update pylint score
+23-Mar-2022  Wayne Shih              Update pylint score
 $HISTORY$
 ================================================================================================-->
 
@@ -19,4 +19,4 @@ $HISTORY$
 [![codecov](https://codecov.io/gh/W-Shih/django-twitter/branch/main/graph/badge.svg?token=D5GVH7WM85)](https://codecov.io/gh/W-Shih/django-twitter)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcf1d5f1fffa46ab86d5ec044d8ce7e5)](https://www.codacy.com/gh/W-Shih/django-twitter/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=W-Shih/django-twitter&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/dcf1d5f1fffa46ab86d5ec044d8ce7e5)](https://www.codacy.com/gh/W-Shih/django-twitter/dashboard?utm_source=github.com&utm_medium=referral&utm_content=W-Shih/django-twitter&utm_campaign=Badge_Coverage)
-[![pylint Score](https://mperlet.github.io/pybadge/badges/9.72.svg)](https://app.travis-ci.com/W-Shih/django-twitter) <!-- https://mperlet.github.io/pybadge/ -->
+[![pylint Score](https://mperlet.github.io/pybadge/badges/9.71.svg)](https://app.travis-ci.com/W-Shih/django-twitter) <!-- https://mperlet.github.io/pybadge/ -->

--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -25,6 +25,7 @@
 # 27-Feb-2022  Wayne Shih              Add DefaultAccountSerializer
 # 17-Mar-2022  Wayne Shih              Add UserSerializerForNotification
 # 20-Mar-2022  Wayne Shih              Create user's profile right after user has been created
+# 23-Mar-2022  Wayne Shih              Update user-related serializer
 # $HISTORY$
 # =================================================================================================
 
@@ -42,29 +43,37 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ('username', 'email')
 
 
-class BaseUserSerializerForDisplay(serializers.ModelSerializer):
+class UserSerializerWithProfile(serializers.ModelSerializer):
+    nickname = serializers.CharField(source='profile.nickname')
+    avatar_url = serializers.SerializerMethodField()
+
     class Meta:
         model = User
-        fields = ('id', 'username')
+        fields = ('id', 'username', 'nickname', 'avatar_url')
+
+    def get_avatar_url(self, obj):
+        if obj.profile.avatar:
+            return obj.profile.avatar.url
+        return None
 
 
-class UserSerializerForTweet(BaseUserSerializerForDisplay):
+class UserSerializerForTweet(UserSerializerWithProfile):
     pass
 
 
-class UserSerializerForFriendship(BaseUserSerializerForDisplay):
+class UserSerializerForFriendship(UserSerializerWithProfile):
     pass
 
 
-class UserSerializerForComment(BaseUserSerializerForDisplay):
+class UserSerializerForComment(UserSerializerWithProfile):
     pass
 
 
-class UserSerializerForLike(BaseUserSerializerForDisplay):
+class UserSerializerForLike(UserSerializerWithProfile):
     pass
 
 
-class UserSerializerForNotification(BaseUserSerializerForDisplay):
+class UserSerializerForNotification(UserSerializerWithProfile):
     pass
 
 

--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -25,13 +25,15 @@
 # 27-Feb-2022  Wayne Shih              Add DefaultAccountSerializer
 # 17-Mar-2022  Wayne Shih              Add UserSerializerForNotification
 # 20-Mar-2022  Wayne Shih              Create user's profile right after user has been created
-# 23-Mar-2022  Wayne Shih              Update user-related serializer
+# 23-Mar-2022  Wayne Shih              Update user-related serializer and add UserProfileSerializerForUpdate
 # $HISTORY$
 # =================================================================================================
 
 
 from django.contrib.auth.models import User
 from rest_framework import exceptions, serializers
+
+from accounts.models import UserProfile
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -144,3 +146,9 @@ class SignupSerializer(serializers.ModelSerializer):
         # Create user's profile right after user has been created
         user.profile
         return user
+
+
+class UserProfileSerializerForUpdate(serializers.ModelSerializer):
+    class Meta:
+        model = UserProfile
+        fields = ('nickname', 'avatar')

--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -42,7 +42,7 @@ class UserSerializer(serializers.ModelSerializer):
     # - https://www.django-rest-framework.org/tutorial/1-serialization/#using-modelserializers
     class Meta:
         model = User
-        fields = ('username', 'email')
+        fields = ('id', 'username')
 
 
 class UserSerializerWithProfile(serializers.ModelSerializer):

--- a/accounts/api/tests.py
+++ b/accounts/api/tests.py
@@ -11,7 +11,7 @@
 # 10-Oct-2021  Wayne Shih              React to pylint checks
 # 27-Feb-2022  Wayne Shih              Add a test for DRF API list page and tests for login
 # 20-Mar-2022  Wayne Shih              Add a test for UserProfile model
-# 23-Mar-2022  Wayne Shih              Add tests for UserProfile API
+# 23-Mar-2022  Wayne Shih              Add tests for UserProfile API, react to serializer change
 # $HISTORY$
 # =================================================================================================
 
@@ -25,7 +25,7 @@ from accounts.models import UserProfile
 from testing.testcases import TestCase
 
 
-DRF_API_LIST_URL = '/api/accounts/'
+ACCOUNTS_BASE_URL = '/api/accounts/'
 LOGIN_URL = '/api/accounts/login/'
 LOGOUT_URL = '/api/accounts/logout/'
 SIGNUP_URL = '/api/accounts/signup/'
@@ -61,7 +61,7 @@ class AccountApiTests(TestCase):
         )
 
     def test_drf_api_list_page(self):
-        response = self.anonymous_client.get(DRF_API_LIST_URL)
+        response = self.anonymous_client.get(ACCOUNTS_BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     # <Wayne Shih> 12-Aug-2021
@@ -135,7 +135,7 @@ class AccountApiTests(TestCase):
         })
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(response.data['user'], None)
-        self.assertEqual(response.data['user']['email'], 'fake_user@twitter.com')
+        self.assertEqual(response.data['user']['id'], self.user.id)
 
         # Check now is at login state  <Wayne Shih> 12-Aug-2021
         response = self.client.get(LOGIN_STATUS_URL)
@@ -249,8 +249,8 @@ class AccountApiTests(TestCase):
         user = User.objects.filter(username=response.data['user']['username']).first()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['success'], True)
-        self.assertEqual(response.data['user']['username'], 'someone')
-        self.assertEqual(response.data['user']['email'], 'someone@fb.com')
+        self.assertEqual(response.data['user']['username'], user.username)
+        self.assertEqual(response.data['user']['id'], user.id)
         self.assertEqual(UserProfile.objects.filter(user_id=user.id).exists(), True)
 
         # Check now is at login state  <Wayne Shih> 12-Aug-2021

--- a/accounts/api/views.py
+++ b/accounts/api/views.py
@@ -15,7 +15,7 @@
 # 21-Aug-2021  Wayne Shih              Add ip information in login_status for django-debug-toolbar
 # 10-Oct-2021  Wayne Shih              React to pylint checks
 # 27-Feb-2021  Wayne Shih              Enhance account api by decorator and GenericViewSet
-# 23-Mar-2022  Wayne Shih              Add UserProfileViewSet
+# 23-Mar-2022  Wayne Shih              Add UserProfileViewSet, update UserViewSet only for superuser
 # $HISTORY$
 # =================================================================================================
 
@@ -37,22 +37,26 @@ from accounts.api.serializers import (
     SignupSerializer,
     UserProfileSerializerForUpdate,
     UserSerializer,
+    UserSerializerWithProfile,
 )
 from accounts.models import UserProfile
 from utils.decorators import required_params
-from utils.permissions import IsObjectOwner
+from utils.permissions import IsObjectOwner, IsSuperuser
 
 
 class UserViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows users to be viewed or deleted by superuser.
     """
     queryset = User.objects.all().order_by('-date_joined')
-    serializer_class = UserSerializer  # the class to render the data to json
+    serializer_class = UserSerializerWithProfile
     # <Wayne Shih> 21-Aug-2021
     # Set permission_classes
     # - https://www.django-rest-framework.org/api-guide/permissions/#api-reference
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = (IsSuperuser,)
+    # <Wayne Shih> 23-Mar-2022
+    # - https://docs.djangoproject.com/en/4.0/ref/class-based-views/base/#django.views.generic.base.View.http_method_names
+    http_method_names = ['get', 'delete', 'head', 'options']
 
 
 # <Wayne Shih> 06-Aug-2021

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -10,7 +10,8 @@
 #
 # =================================================================================================
 #    Date      Name                    Description of Change
-# 19-Mar-2021  Wayne Shih              Initial create
+# 19-Mar-2022  Wayne Shih              Initial create
+# 23-Mar-2022  Wayne Shih              Update UserProfile's __str__
 # $HISTORY$
 # =================================================================================================
 
@@ -29,9 +30,10 @@ class UserProfile(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        message = 'Profile {user}-{user_id} with nickname-{nickname} and avatar-{avatar}' \
-                  'was created at {created_at} and updated at {updated_at}.'
+        message = 'Profile-[{id}]: {user}-[{user_id}] with nickname-[{nickname}] and ' \
+                  'avatar-[{avatar}] was created at {created_at} and updated at {updated_at}.'
         return message.format(
+            id=self.id,
             user=self.user,
             user_id=self.user_id,
             nickname=self.nickname,

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -6,7 +6,8 @@
 #
 # =================================================================================================
 #    Date      Name                    Description of Change
-# 19-Mar-2021  Wayne Shih              Initial create
+# 19-Mar-2022  Wayne Shih              Initial create
+# 23-Mar-2022  Wayne Shih              React to UserProfile's updates
 # $HISTORY$
 # =================================================================================================
 
@@ -48,9 +49,10 @@ class UserProfileTests(TestCase):
             str(lbj23_profile.user_id) in str(lbj23_profile),
             True
         )
-        message = 'Profile {user}-{user_id} with nickname-{nickname} and avatar-{avatar}' \
-                  'was created at {created_at} and updated at {updated_at}.'
+        message = 'Profile-[{id}]: {user}-[{user_id}] with nickname-[{nickname}] and ' \
+                  'avatar-[{avatar}] was created at {created_at} and updated at {updated_at}.'
         self.assertEqual(message.format(
+            id=lbj23_profile.id,
             user=lbj23_profile.user,
             user_id=lbj23_profile.user_id,
             nickname=lbj23_profile.nickname,

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -14,6 +14,7 @@
 # 23-Feb-2022  Wayne Shih              React to enhancement by django-filters: filterset_class
 # 27-Feb-2022  Wayne Shih              React to enhancement by decorator and add tests for update
 # 12-Mar-2022  Wayne Shih              React to serializer changes and add tests for comments_count
+# 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # $HISTORY$
 # =================================================================================================
 
@@ -100,6 +101,8 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.data['user'], {
             'id': self.kd35.id,
             'username': self.kd35.username,
+            'nickname': self.kd35.profile.nickname,
+            'avatar_url': self.get_avator_url(self.kd35),
         })
         self.assertEqual(response.data['tweet_id'], self.tweet.id)
         self.assertEqual(response.data['content'], 'Good 4 u, my bro!')
@@ -200,6 +203,8 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.data['user'], {
             'id': self.lbj23.id,
             'username': self.lbj23.username,
+            'nickname': self.lbj23.profile.nickname,
+            'avatar_url': self.get_avator_url(self.lbj23),
         })
         self.assertEqual(response.data['content'], new_comment)
         self.assertEqual(comment.created_at, old_created_at)

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -11,6 +11,7 @@
 # 04-Nov-2021  Wayne Shih              React to adding anonymous_client to base class
 # 06-Nov-2021  Wayne Shih              Modify some assertEqual to check set instead of list
 # 13-Nov-2021  Wayne Shih              Update non_existing_user_id larger to Fix test fail
+# 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # $HISTORY$
 # =================================================================================================
 
@@ -68,7 +69,10 @@ class FriendshipApiTests(TestCase):
         self.assertEqual(isinstance(followers, list), True)
         self.assertEqual(len(followers), 2)
         self.assertEqual(set(followers[0].keys()), {'from_user', 'created_at'})
-        self.assertEqual(set(followers[0].get('from_user')), {'id', 'username'})
+        self.assertEqual(
+            set(followers[0].get('from_user')),
+            {'id', 'username', 'nickname', 'avatar_url'}
+        )
         # <Wayne Shih> 06-Sep-2021
         # test order by '-created_at'
         for i in range(len(followers) - 1):
@@ -98,7 +102,10 @@ class FriendshipApiTests(TestCase):
         self.assertEqual(isinstance(followings, list), True)
         self.assertEqual(len(followings), 3)
         self.assertEqual(set(followings[0].keys()), {'user', 'created_at'})
-        self.assertEqual(set(followings[0].get('user')), {'id', 'username'})
+        self.assertEqual(
+            set(followings[0].get('user')),
+            {'id', 'username', 'nickname', 'avatar_url'}
+        )
         # <Wayne Shih> 06-Sep-2021
         # test order by '-created_at'
         for i in range(len(followings) - 1):

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -9,6 +9,7 @@
 # 26-Feb-2022  Wayne Shih              Initial create
 # 05-Mar-2022  Wayne Shih              Add tests for like cancel and list APIs
 # 12-Mar-2022  Wayne Shih              Add tests for likes in tweets and comments
+# 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # $HISTORY$
 # =================================================================================================
 
@@ -132,6 +133,8 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.data['user'], {
             'id': self.lbj23.id,
             'username': self.lbj23.username,
+            'nickname': self.lbj23.profile.nickname,
+            'avatar_url': self.get_avator_url(self.lbj23),
         })
         self.assertEqual(likes_count, 1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ coverage==5.5
 pylint==2.11.1
 django-filter==21.1
 django-notifications-hq==1.7.0
+boto3==1.21.23
+django-storages==1.12.3

--- a/requirements_bak
+++ b/requirements_bak
@@ -3,6 +3,8 @@ asn1crypto==0.24.0
 astroid==2.8.2
 attrs==17.4.0
 Automat==0.6.0
+boto3==1.21.23
+botocore==1.24.23
 certifi==2018.1.18
 chardet==3.0.4
 click==6.7
@@ -17,12 +19,14 @@ django-debug-toolbar==3.2.1
 django-filter==21.1
 django-model-utils==4.2.0
 django-notifications-hq==1.7.0
+django-storages==1.12.3
 djangorestframework==3.12.4
 httplib2==0.9.2
 hyperlink==17.3.1
 idna==2.6
 incremental==16.10.1
 isort==5.9.3
+jmespath==0.10.0
 jsonfield==3.1.0
 keyring==10.6.0
 keyrings.alt==3.0
@@ -41,12 +45,14 @@ pylint==2.11.1
 pyOpenSSL==17.5.0
 pyserial==3.4
 python-apt==1.6.4
+python-dateutil==2.8.2
 python-debian==0.1.32
 pytz==2021.1
 pyxdg==0.25
 PyYAML==3.12
 requests==2.18.4
 requests-unixsocket==0.1.5
+s3transfer==0.5.2
 SecretStorage==2.3.1
 service-identity==16.0.0
 six==1.11.0
@@ -59,6 +65,6 @@ Twisted==17.9.0
 typed-ast==1.4.3
 typing-extensions==3.10.0.0
 ufw==0.36
-urllib3==1.22
+urllib3==1.26.9
 wrapt==1.12.1
 zope.interface==4.3.2

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -15,6 +15,7 @@
 # 24-Feb-2022  Wayne Shih              Add create_like
 # 26-Feb-2022  Wayne Shih              Add create_user_and_auth_client
 # 12-Mar-2022  Wayne Shih              Add create_newsfeed
+# 23-Mar-2022  Wayne Shih              Add get_avator_url
 # $HISTORY$
 # =================================================================================================
 
@@ -81,3 +82,6 @@ class TestCase(DjangoTestCase):
 
     def create_newsfeed(self, user, tweet):
         return NewsFeed.objects.create(user=user, tweet=tweet)
+
+    def get_avator_url(self, user):
+        return user.profile.avatar.url if user.profile.avatar else None

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -14,6 +14,7 @@
 # 27-Nov-2021  Wayne Shih              React to decorator enhancement
 # 23-Feb-2022  Wayne Shih              Add a test for tweet list api
 # 12-Mar-2022  Wayne Shih              React to serializer changes
+# 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # $HISTORY$
 # =================================================================================================
 
@@ -129,6 +130,8 @@ class TweetApiTests(TestCase):
         self.assertEqual(response.data['user'], {
             'id': self.user1.id,
             'username': self.user1.username,
+            'nickname': self.user1.profile.nickname,
+            'avatar_url': self.get_avator_url(self.user1),
         })
         self.assertEqual(
             set(response.data.keys()),
@@ -161,7 +164,10 @@ class TweetApiTests(TestCase):
                 'likes',
             }
         )
-        self.assertEqual(response.json().get('user').keys(), {'id', 'username'})
+        self.assertEqual(
+            response.json().get('user').keys(),
+            {'id', 'username', 'nickname', 'avatar_url'}
+        )
         self.assertEqual(isinstance(response.json().get('comments'), list), True)
         self.assertEqual(len(response.data['comments']), 0)
 

--- a/twitter/local_settings.example.py
+++ b/twitter/local_settings.example.py
@@ -1,4 +1,23 @@
-# checkout https://www.neilwithdata.com/django-sql-logging
+# =================================================================================================
+#                                  All Rights Reserved.
+# =================================================================================================
+# File description:
+#       local settings for local dev env to override settings.py
+#       This is an example file, modify it as need.
+# Note:
+#       local_setting.py is used for local dev env ONLY.
+#       Do NOT push local_setting.py to github repo.
+#
+# =================================================================================================
+#    Date      Name                    Description of Change
+# 06-Nov-2021  Wayne Shih              Initial settings
+# 23-Mar-2022  Wayne Shih              Add AWS-related env variables
+# $HISTORY$
+# =================================================================================================
+
+# <Wayne Shih> 06-Nov-2021
+# Dev logging
+# https://www.neilwithdata.com/django-sql-logging
 LOGGING = {
     'version': 1,
     'filters': {
@@ -20,3 +39,17 @@ LOGGING = {
         }
     }
 }
+
+# <Wayne Shih> 20-Mar-2022
+# AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY are confidential.
+# Do NOT add these information in settings.py
+# The other option is to set them as environment variables instead.
+# https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+#
+# AWS_ACCESS_KEY_ID = 'YOUR_ACCESS_KEY_ID'
+# AWS_SECRET_ACCESS_KEY = 'YOUR_SECRET_ACCESS_KEY'
+#
+# The other option is to set them as environment variables instead.
+# This way it can be written in settings.py
+# AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+# AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -19,6 +19,7 @@
 # 25-Nov-2021  Wayne Shih              Add django_filters
 # 24-Feb-2022  Wayne Shih              Add likes
 # 12-Mar-2022  Wayne Shih              Add notifications and inbox
+# 23-Mar-2022  Wayne Shih              Add MEDIA_ROOT, DEFAULT_FILE_STORAGE, AWS-related variables
 # $HISTORY$
 # =================================================================================================
 
@@ -33,6 +34,9 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
+
+import os
+import sys
 
 from pathlib import Path
 
@@ -173,8 +177,32 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
-
 STATIC_URL = '/static/'
+
+# <Wayne Shih> 20-Mar-2022
+# https://docs.djangoproject.com/en/3.1/ref/settings/#media-root
+MEDIA_ROOT = './media/'
+
+# <Wayne Shih> 20-Mar-2022
+# Amazon S3 with django-storages
+# https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+# https://docs.djangoproject.com/en/3.1/ref/settings/#default-file-storage
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+TESTING = ((' '.join(sys.argv)).find('manage.py test') != -1)
+if TESTING:
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+
+AWS_STORAGE_BUCKET_NAME = 'django.twitter'
+AWS_S3_REGION_NAME = 'us-west-1'
+
+# <Wayne Shih> 20-Mar-2022
+# AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY are confidential.
+# Do NOT add these information in settings.py
+# Please set them in local_settings.py
+#
+# The other option is to set them as environment variables instead.
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 
 try:
     from .local_settings import *

--- a/twitter/urls.py
+++ b/twitter/urls.py
@@ -17,6 +17,7 @@
 # 06-Nov-2021  Wayne Shih              Register router CommentViewSet
 # 26-Feb-2022  Wayne Shih              Register router LikeViewSet
 # 17-Mar-2022  Wayne Shih              Register router NotificationViewSet
+# 23-Mar-2022  Wayne Shih              Register router UserProfileViewSet
 # $HISTORY$
 # =================================================================================================
 
@@ -42,7 +43,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 
-from accounts.api.views import AccountViewSet, UserViewSet
+from accounts.api.views import AccountViewSet, UserViewSet, UserProfileViewSet
 from comments.api.views import CommentViewSet
 from friendships.api.views import FriendshipViewSet
 from inbox.api.views import NotificationViewSet
@@ -62,6 +63,7 @@ router.register(r'api/newsfeeds', NewsFeedViewSet, basename='newsfeeds')
 router.register(r'api/comments', CommentViewSet, basename='comments')
 router.register(r'api/likes', LikeViewSet, basename='likes')
 router.register(r'api/notifications', NotificationViewSet, basename='notifications')
+router.register(r'api/profiles', UserProfileViewSet, basename='profiles')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -13,6 +13,7 @@
 #    Date      Name                    Description of Change
 # 13-Nov-2021  Wayne Shih              Initial create
 # 19-Mar-2022  Wayne Shih              Move this file to utils, extend has_object_permission, modify some comments
+# 23-Mar-2022  Wayne Shih              Add IsSuperuser
 # $HISTORY$
 # =================================================================================================
 
@@ -41,5 +42,12 @@ class IsObjectOwner(BasePermission):
         #
         # <Wayne Shih> 19-Mar-2021
         # Extend this check for notification to use.
-        return request.user == getattr(obj, 'user', None) or \
-               request.user == getattr(obj, 'recipient', None)
+        return (
+            request.user == getattr(obj, 'user', None) or
+            request.user == getattr(obj, 'recipient', None)
+        )
+
+
+class IsSuperuser(BasePermission):
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_superuser)


### PR DESCRIPTION
- settings: set file storage and amazon s3
- feature: update user-related serializer to render nickname & avatar
- feature-and-test: add user profile update api and tests
  - user is able to update nickname and avatar
- feature: update UserSerializer
- feature-and-test: update UserViewSet only for superuser and add tests
  - user api allows users to be viewed or deleted by superusers only
- doc: update pylint score