### PR TITLE
feature-and-test: add friendship pagination with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ File description:
 24-Aug-2021  Wayne Shih              Initial create and add badges
 17-Oct-2021  Wayne Shih              Add codacy badges
 06-Nov-2021  Wayne Shih              Add pylint badge
-30-Mar-2022  Wayne Shih              Update pylint score
+02-Apr-2022  Wayne Shih              Update pylint score
 $HISTORY$
 ================================================================================================-->
 
@@ -19,4 +19,4 @@ $HISTORY$
 [![codecov](https://codecov.io/gh/W-Shih/django-twitter/branch/main/graph/badge.svg?token=D5GVH7WM85)](https://codecov.io/gh/W-Shih/django-twitter)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcf1d5f1fffa46ab86d5ec044d8ce7e5)](https://www.codacy.com/gh/W-Shih/django-twitter/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=W-Shih/django-twitter&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/dcf1d5f1fffa46ab86d5ec044d8ce7e5)](https://www.codacy.com/gh/W-Shih/django-twitter/dashboard?utm_source=github.com&utm_medium=referral&utm_content=W-Shih/django-twitter&utm_campaign=Badge_Coverage)
-[![pylint Score](https://mperlet.github.io/pybadge/badges/9.72.svg)](https://app.travis-ci.com/W-Shih/django-twitter) <!-- https://mperlet.github.io/pybadge/ -->
+[![pylint Score](https://mperlet.github.io/pybadge/badges/9.73.svg)](https://app.travis-ci.com/W-Shih/django-twitter) <!-- https://mperlet.github.io/pybadge/ -->

--- a/friendships/api/pagination.py
+++ b/friendships/api/pagination.py
@@ -1,0 +1,54 @@
+# =================================================================================================
+#                                  All Rights Reserved.
+# =================================================================================================
+# File description:
+#       Override the pagination class to define our own pagination style for friendships api
+#
+#       Ref: https://www.django-rest-framework.org/api-guide/pagination/
+#
+# =================================================================================================
+#    Date      Name                    Description of Change
+# 02-Apr-2021  Wayne Shih              Initial create
+# $HISTORY$
+# =================================================================================================
+
+
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class FriendshipPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 20
+
+    # <Wayne Shih> 02-Apr-2022
+    # https://www.django-rest-framework.org/api-guide/pagination/#modifying-the-pagination-style
+    # https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles
+    def get_paginated_response(self, data):
+        return Response({
+            'count': self.page.paginator.count,
+            'num_pages': self.page.paginator.num_pages,
+            'page_number': self.page.number,
+            'has_previous': self.page.has_previous(),
+            'previous': self.get_previous_link(),
+            'has_next': self.page.has_next(),
+            'next': self.get_next_link(),
+            'results': data,
+        })
+
+    # <Wayne Shih> 02-Apr-2022
+    # TODO:
+    #   Remove this method after front-end & app-end deprecate keys 'followings' & 'followers'.
+    def get_customized_paginated_response(self, data, deprecated_key):
+        return Response({
+            'count': self.page.paginator.count,
+            'num_pages': self.page.paginator.num_pages,
+            'page_number': self.page.number,
+            'has_previous': self.page.has_previous(),
+            'previous': self.get_previous_link(),
+            'has_next': self.page.has_next(),
+            'next': self.get_next_link(),
+            'results': data,
+            f'{str(deprecated_key)}': data,
+        })


### PR DESCRIPTION
- feature: add friendships pagination
- tests: add tests for friendships pagination
- doc: update pylint
- TODO: Remove old key 'followings' and 'followers' after the front-end & app-end deprecate them.