### PR TITLE
feature: deprecate-keys-in-friendships-apis

### DIFF
--- a/friendships/api/pagination.py
+++ b/friendships/api/pagination.py
@@ -9,6 +9,7 @@
 # =================================================================================================
 #    Date      Name                    Description of Change
 # 02-Apr-2021  Wayne Shih              Initial create
+# 03-Apr-2022  Wayne Shih              React to deprecating keys in friendships apis
 # $HISTORY$
 # =================================================================================================
 
@@ -35,20 +36,4 @@ class FriendshipPagination(PageNumberPagination):
             'has_next': self.page.has_next(),
             'next': self.get_next_link(),
             'results': data,
-        })
-
-    # <Wayne Shih> 02-Apr-2022
-    # TODO:
-    #   Remove this method after front-end & app-end deprecate keys 'followings' & 'followers'.
-    def get_customized_paginated_response(self, data, deprecated_key):
-        return Response({
-            'count': self.page.paginator.count,
-            'num_pages': self.page.paginator.num_pages,
-            'page_number': self.page.number,
-            'has_previous': self.page.has_previous(),
-            'previous': self.get_previous_link(),
-            'has_next': self.page.has_next(),
-            'next': self.get_next_link(),
-            'results': data,
-            f'{str(deprecated_key)}': data,
         })

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -14,6 +14,7 @@
 # 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # 02-Apr-2022  Wayne Shih              Add tests for friendships pagination
 # 03-Apr-2022  Wayne Shih              Add tests for followers & followings pagination, react to adding has_followed
+# 03-Apr-2022  Wayne Shih              React to deprecating keys in friendships apis
 # $HISTORY$
 # =================================================================================================
 
@@ -72,7 +73,7 @@ class FriendshipApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
         response = self.anonymous_client.get(url)
-        followers = response.data['followers']
+        followers = response.data['results']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(isinstance(followers, list), True)
         self.assertEqual(len(followers), 2)
@@ -105,7 +106,7 @@ class FriendshipApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
         response = self.anonymous_client.get(url)
-        followings = response.data['followings']
+        followings = response.data['results']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(isinstance(followings, list), True)
         self.assertEqual(len(followings), 3)

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -14,6 +14,7 @@
 # 27-Feb-2021  Wayne Shih              Change default serializer
 # 02-Apr-2022  Wayne Shih              Add friendships pagination
 # 03-Apr-2022  Wayne Shih              React to adding has_followed
+# 03-Apr-2022  Wayne Shih              Deprecate keys in friendships apis, fix typo
 # $HISTORY$
 # =================================================================================================
 
@@ -40,15 +41,6 @@ class FriendshipViewSet(viewsets.GenericViewSet):
     serializer_class = DefaultFriendshipSerializer
     pagination_class = FriendshipPagination
 
-    # <Wayne Shih> 02-Apr-2022
-    # TODO:
-    #   Remove this method after front-end & app-end deprecate keys 'followings' & 'followers'.
-    def _get_paginated_response(self, data, deprecated_key=None):
-        assert self.paginator is not None
-        if not deprecated_key:
-            return self.paginator.get_paginated_response(data)
-        return self.paginator.get_customized_paginated_response(data, deprecated_key)
-
     def list(self, request):
         return Response({
             'message': {
@@ -62,7 +54,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
                 },
                 'Follow someone': {
                     'method': 'POST',
-                    'url': 'api/friendships/{to_user_id_pk}/follow/',
+                    'url': '/api/friendships/{to_user_id_pk}/follow/',
                 },
                 'Unfollow someone': {
                     'method': 'POST',
@@ -79,10 +71,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         # https://www.django-rest-framework.org/api-guide/viewsets/#marking-extra-actions-for-routing
         page = self.paginate_queryset(followers)
         serializer = FollowerSerializer(page, many=True, context={'request': request})
-        # <Wayne Shih> 02-Apr-2022
-        # TODO:
-        #   Remove key 'followers' after front-end & app-end deprecate it.
-        return self._get_paginated_response(serializer.data, 'followers')
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
     def followings(self, request, pk):
@@ -90,10 +79,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         followings = Friendship.objects.filter(from_user_id=from_user.id).order_by('-created_at')
         page = self.paginate_queryset(followings)
         serializer = FollowingSerializer(page, many=True, context={'request': request})
-        # <Wayne Shih> 02-Apr-2022
-        # TODO:
-        #   Remove key 'followings' after front-end & app-end deprecate it.
-        return self._get_paginated_response(serializer.data, 'followings')
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
     def follow(self, request: Request, pk):


### PR DESCRIPTION
This PR is a follow-up task leftover in https://github.com/W-Shih/django-twitter/pull/43#issue-1190821687.
Because front-end & app-end have deprecated keys 'followings' & 'followers' and use key 'results' instead,
this PR is to finish this task.
- feature: deprecate keys, 'followings' and 'followers', in friendships APIs and clean up some method/function.