### PR TITLE
feature: deprecate key in newsfeeds list api

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -16,6 +16,7 @@
 # 12-Mar-2022  Wayne Shih              React to serializer changes and add tests for comments_count
 # 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # 29-Apr-2022  Wayne Shih              React to deprecating key in tweets list api
+# 29-Apr-2022  Wayne Shih              React to deprecating key in newsfeeds list api
 # $HISTORY$
 # =================================================================================================
 
@@ -339,4 +340,4 @@ class CommentApiTests(TestCase):
         self.create_newsfeed(self.kd35, self.tweet)
         response = self.kd35_client.get(NEWSFEED_LIST_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['comments_count'], 2)

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -11,6 +11,7 @@
 # 12-Mar-2022  Wayne Shih              Add tests for likes in tweets and comments
 # 23-Mar-2022  Wayne Shih              React to user-related serializer changes
 # 29-Apr-2022  Wayne Shih              React to deprecating key in tweets list api
+# 29-Apr-2022  Wayne Shih              React to deprecating key in newsfeeds list api
 # $HISTORY$
 # =================================================================================================
 
@@ -357,8 +358,8 @@ class LikeApiTests(TestCase):
         self.create_newsfeed(self.kd35, self.lbj23_tweet)
         response = self.kd35_client.get(NEWSFEED_LIST_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['has_liked'], True)
 
         # test likes and their detail in tweet detail
         url = TWEET_DETAIL_URL.format(self.lbj23_tweet.id)

--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -8,6 +8,7 @@
 #    Date      Name                    Description of Change
 # 04-Nov-2021  Wayne Shih              Initial create
 # 27-Apr-2022  Wayne Shih              Add tests for newfeed list endless pagination
+# 29-Apr-2022  Wayne Shih              React to deprecating key in newsfeeds list api
 # $HISTORY$
 # =================================================================================================
 
@@ -49,19 +50,19 @@ class NewsFeedApiTests(TestCase):
         # test authenticated user with GET
         response = self.lbj23_client.get(NEWSFEED_LIST_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['newsfeeds']), 0)
+        self.assertEqual(len(response.data['results']), 0)
 
         # test seeing user's own tweet
         self.lbj23_client.post(TWEET_CREATE_URL, {'content': 'I am the King James!'})
         response = self.lbj23_client.get(NEWSFEED_LIST_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['newsfeeds']), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
         # able to see someone's tweet after following
         self.lbj23_client.post(FOLLOW_URL.format(self.kobe24.id))
         self.kobe24_client.post(TWEET_CREATE_URL, {'content': 'Be Better!'})
         response = self.lbj23_client.get(NEWSFEED_LIST_URL)
-        newsfeeds = response.data['newsfeeds']
+        newsfeeds = response.data['results']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(newsfeeds), 2)
         self.assertEqual(newsfeeds[0]['created_at'] > newsfeeds[1]['created_at'], True)
@@ -81,10 +82,10 @@ class NewsFeedApiTests(TestCase):
         response = self.lbj23_client.get(NEWSFEED_LIST_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['has_next'], True)
-        self.assertEqual(len(response.data['newsfeeds']), page_size)
-        self.assertEqual(response.data['newsfeeds'][0]['id'], newsfeeds[0].id)
+        self.assertEqual(response.data['results'][0]['id'], newsfeeds[0].id)
+        self.assertEqual(len(response.data['results']), page_size)
         self.assertEqual(
-            response.data['newsfeeds'][page_size - 1]['id'],
+            response.data['results'][page_size - 1]['id'],
             newsfeeds[page_size - 1].id
         )
         self.assertEqual(
@@ -103,10 +104,10 @@ class NewsFeedApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['has_next'], False)
         self.assertEqual(response.data['next'], None)
-        self.assertEqual(len(response.data['newsfeeds']), page_size - 1)
-        self.assertEqual(response.data['newsfeeds'][0]['id'], newsfeeds[page_size].id)
+        self.assertEqual(len(response.data['results']), page_size - 1)
+        self.assertEqual(response.data['results'][0]['id'], newsfeeds[page_size].id)
         self.assertEqual(
-            response.data['newsfeeds'][page_size - 2]['id'],
+            response.data['results'][page_size - 2]['id'],
             newsfeeds[page_size * 2 - 2].id
         )
 
@@ -116,7 +117,7 @@ class NewsFeedApiTests(TestCase):
         })
         self.assertEqual(response.data['has_next'], False)
         self.assertEqual(response.data['next'], None)
-        self.assertEqual(len(response.data['newsfeeds']), 0)
+        self.assertEqual(len(response.data['results']), 0)
 
         new_tweet1 = self.create_tweet(self.lbj23, 'lbj23::new_tweet::1')
         new_tweet2 = self.create_tweet(self.lbj23, 'lbj23::new_tweet::2')
@@ -127,6 +128,6 @@ class NewsFeedApiTests(TestCase):
         })
         self.assertEqual(response.data['has_next'], False)
         self.assertEqual(response.data['next'], None)
-        self.assertEqual(len(response.data['newsfeeds']), 2)
-        self.assertEqual(response.data['newsfeeds'][0]['id'], new_newsfeed2.id)
-        self.assertEqual(response.data['newsfeeds'][1]['id'], new_newsfeed1.id)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['results'][0]['id'], new_newsfeed2.id)
+        self.assertEqual(response.data['results'][1]['id'], new_newsfeed1.id)

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -12,6 +12,7 @@
 # 04-Nov-2021  Wayne Shih              Initial create
 # 12-Mar-2022  Wayne Shih              React to tweet serializer changes
 # 27-Apr-2022  Wayne Shih              Add endless pagination for newsfeed list api
+# 29-Apr-2022  Wayne Shih              Deprecate key in newsfeeds list api
 # $HISTORY$
 # =================================================================================================
 
@@ -28,15 +29,6 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = (IsAuthenticated,)
     pagination_class = EndlessPagination
 
-    # <Wayne Shih> 27-Apr-2022
-    # TODO:
-    #   Remove this method after front-end & app-end deprecate keys 'newsfeeds'.
-    def _get_paginated_response(self, data, deprecated_key=None):
-        assert self.paginator is not None
-        if not deprecated_key:
-            return self.paginator.get_paginated_response(data)
-        return self.paginator.get_customized_paginated_response(data, deprecated_key)
-
     def get_queryset(self):
         return NewsFeed.objects.filter(user=self.request.user)
 
@@ -49,7 +41,4 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         newsfeeds = self.get_queryset().order_by('-created_at')
         page = self.paginate_queryset(newsfeeds)
         serializer = NewsFeedSerializer(page, many=True, context={'request': request})
-        # <Wayne Shih> 27-Apr-2022
-        # TODO:
-        #   Remove key 'newsfeeds' after front-end & app-end deprecate it.
-        return self._get_paginated_response(serializer.data, 'newsfeeds')
+        return self.get_paginated_response(serializer.data)

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -11,6 +11,7 @@
 # 26-Apr-2021  Wayne Shih              Initial create
 # 27-Apr-2021  Wayne Shih              Refactor being under util and rename to EndlessPagination
 # 28-Apr-2021  Wayne Shih              Add generic key to render endless pagination results
+# 29-Apr-2022  Wayne Shih              React to deprecating keys in tweets and newsfeeds list api
 # $HISTORY$
 # =================================================================================================
 
@@ -70,17 +71,6 @@ class EndlessPagination(BasePagination):
             'has_next': self.has_next,
             'next': self._get_next_link(data),
             'results': data,
-        })
-
-    # <Wayne Shih> 25-Apr-2022
-    # TODO:
-    #   Remove this method after front-end & app-end deprecate keys 'tweets'.
-    def get_customized_paginated_response(self, data, deprecated_key):
-        return Response({
-            'has_next': self.has_next,
-            'next': self._get_next_link(data),
-            'results': data,
-            f'{str(deprecated_key)}': data,
         })
 
     def to_html(self):


### PR DESCRIPTION
Front-end has deprecated keys in tweets and newsfeeds list api, this PR is to deprecate these keys as react.
- feature: deprecate key in newsfeeds list api
- test: react to deprecating key in newsfeeds list api