### PR TITLE
enhance: make async fanout newsfeeds robust

### DIFF
--- a/friendships/services.py
+++ b/friendships/services.py
@@ -11,6 +11,7 @@
 # 30-Apr-2022  Wayne Shih              Add get_following_user_id_set() & invalidate_followings_cache()
 # 26-May-2022  Wayne Shih              Add print to debug github travis CI
 # 26-May-2022  Wayne Shih              Remove debug print for github travis CI
+# 12-Jun-2022  Wayne Shih              Deprecate get_followers()
 # $HISTORY$
 # =================================================================================================
 
@@ -34,51 +35,6 @@ class FriendshipService(object):
             for friendship in follower_friendships
         ]
         return follower_ids
-
-    @classmethod
-    def get_followers(cls, user_id):
-
-        # <Wayne Shih> 18-Oct-2021
-        # Sol1 - (X)
-        # This exactly causes (1 + N) queries. Not good!
-        #
-        # follower_friendships = Friendship.objects.filter(to_user_id=user_id)
-        # return [friendship.from_user for friendship in follower_friendships]
-
-        # <Wayne Shih> 18-Oct-2021
-        # Sol2 - (X)
-        # Use SQL join
-        # - https://docs.djangoproject.com/en/3.2/ref/models/querysets/#select-related
-        #
-        # follower_friendships = Friendship.objects.filter(
-        #     to_user_id=user_id
-        # ).select_related('from_user')
-        # followers = [friendship.from_user for friendship in follower_friendships]
-        # return followers
-
-        # <Wayne Shih> 18-Oct-2021
-        # Sol3 - (O)
-        # Use SQL in query (bulk select)
-        # - https://docs.djangoproject.com/en/3.2/ref/models/querysets/#in
-        #
-        # follower_friendships = Friendship.objects.filter(to_user_id=user_id)
-        # follower_ids = [
-        #     friendship.from_user_id
-        #     for friendship in follower_friendships
-        # ]
-        # followers = User.objects.filter(id__in=follower_ids)
-        # return list(followers)
-
-        # <Wayne Shih> 18-Oct-2021
-        # Sol4 - (O)
-        # Use Django ORM prefetch, which is equivalent to SQL in query
-        # - https://docs.djangoproject.com/en/3.2/ref/models/querysets/#prefetch-related
-        #
-        follower_friendships = Friendship.objects.filter(
-            to_user_id=user_id
-        ).prefetch_related('from_user')
-        followers = [friendship.from_user for friendship in follower_friendships]
-        return followers
 
     @classmethod
     def get_following_user_id_set(cls, from_user_id):

--- a/newsfeeds/constants.py
+++ b/newsfeeds/constants.py
@@ -1,0 +1,16 @@
+# =================================================================================================
+#                                  All Rights Reserved.
+# =================================================================================================
+# File description:
+#     Define constants for NewsFeed especially
+#
+# =================================================================================================
+#    Date      Name                    Description of Change
+# 12-Jun-2022  Wayne Shih              Initial create
+# $HISTORY$
+# =================================================================================================
+
+
+from django.conf import settings
+
+FANOUT_BATCH_SIZE = 1000 if not settings.TESTING else 3

--- a/newsfeeds/services.py
+++ b/newsfeeds/services.py
@@ -9,12 +9,13 @@
 # 18-Oct-2021  Wayne Shih              Initial create
 # 30-May-2022  Wayne Shih              Add uer newsfeeds cache, react to redis helper
 # 12-Jun-2022  Wayne Shih              Use message queue to fanout newsfeeds
+# 12-Jun-2022  Wayne Shih              Make fanout robust
 # $HISTORY$
 # =================================================================================================
 
 
 from newsfeeds.models import NewsFeed
-from newsfeeds.tasks import fanout_newsfeeds_task
+from newsfeeds.tasks import fanout_newsfeeds_main_task
 from tweets.models import Tweet
 from twitter.caches import USER_NEWSFEEDS_PATTERN
 from utils.caches.redis_helpers import RedisHelper
@@ -27,7 +28,7 @@ class NewsFeedService(object):
         # <Wayne Shih> 11-Jun-2022
         # User should be able to see own tweet as soon as possible
         NewsFeed.objects.create(user_id=tweet.user_id, tweet_id=tweet.id)
-        fanout_newsfeeds_task.delay(tweet.id, tweet.user_id)
+        fanout_newsfeeds_main_task.delay(tweet.id, tweet.user_id)
 
     @classmethod
     def get_cached_newsfeeds(cls, user_id):

--- a/newsfeeds/tasks.py
+++ b/newsfeeds/tasks.py
@@ -9,6 +9,7 @@
 # =================================================================================================
 #    Date      Name                    Description of Change
 # 12-Jun-2022  Wayne Shih              Initial create
+# 12-Jun-2022  Wayne Shih              Make fanout robust
 # $HISTORY$
 # =================================================================================================
 
@@ -16,15 +17,28 @@
 from celery import shared_task
 
 from friendships.services import FriendshipService
+from newsfeeds.constants import FANOUT_BATCH_SIZE
 from newsfeeds.models import NewsFeed
 from utils.time_constants import ONE_HOUR
 
 
-@shared_task(time_limit=ONE_HOUR)
-def fanout_newsfeeds_task(tweet_id, tweet_user_id):
+@shared_task(routing_key='default', time_limit=ONE_HOUR)
+def fanout_newsfeeds_main_task(tweet_id, tweet_user_id):
+    follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
+    batch_from, batch_end = 0, FANOUT_BATCH_SIZE
+    while len(follower_ids[batch_from:batch_end]) > 0:
+        fanout_newsfeeds_batch_task.delay(tweet_id, follower_ids[batch_from:batch_end])
+        batch_from, batch_end = batch_end, batch_end + FANOUT_BATCH_SIZE
+
+    return f'{len(follower_ids) // FANOUT_BATCH_SIZE + 1} batches created, '\
+           f'going to fanout {len(follower_ids)} newsfeeds.'
+
+
+@shared_task(routing_key='newsfeeds', time_limit=ONE_HOUR)
+def fanout_newsfeeds_batch_task(tweet_id, follower_ids):
     from newsfeeds.services import NewsFeedService
 
-    follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
+    # follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
     newsfeeds = [
         NewsFeed(user_id=follower_id, tweet_id=tweet_id)
         for follower_id in follower_ids
@@ -38,3 +52,5 @@ def fanout_newsfeeds_task(tweet_id, tweet_user_id):
     # so here needs to push newsfeeds to cache on our own.
     for newsfeed in newsfeeds:
         NewsFeedService.push_newsfeed_to_cache(newsfeed)
+
+    return f'{len(newsfeeds)} newsfeeds created.'

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -24,6 +24,7 @@
 # 28-May-2022  Wayne Shih              Add redis
 # 05-Jun-2022  Wayne Shih              Only cache REDIS_LIST_SIZE_LIMIT in redis
 # 12-Jun-2022  Wayne Shih              Add celery settings and use redis as MQ broker, fix lint
+# 12-Jun-2022  Wayne Shih              Add CELERY_QUEUES for routing tasks
 # $HISTORY$
 # =================================================================================================
 
@@ -43,6 +44,8 @@ import os
 import sys
 
 from pathlib import Path
+
+from kombu import Queue
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -252,6 +255,15 @@ REDIS_LIST_SIZE_LIMIT = 200 if not TESTING else 15
 CELERY_BROKER_URL = 'redis://127.0.0.1:6379/2' if not TESTING else 'redis://127.0.0.1:6379/0'
 CELERY_TIMEZONE = 'UTC'
 CELERY_TASK_ALWAYS_EAGER = TESTING
+# <Wayne Shih> 12-Jun-2022
+# Celery task queues
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_queues
+# https://docs.celeryq.dev/projects/kombu/en/master/reference/kombu.html#kombu.Queue
+# https://docs.celeryq.dev/en/stable/userguide/routing.html#id2
+CELERY_QUEUES = (
+    Queue('default', routing_key='default'),
+    Queue('newsfeeds', routing_key='newsfeeds'),
+)
 
 try:
     from .local_settings import *


### PR DESCRIPTION
- enhance: make async fanout newsfeeds robust
- tests: add tests for fanout_newsfeeds_main_task()
- Deprecate get_followers() because only get_follower_ids() is needed